### PR TITLE
Add US-MMS site filtering notebook

### DIFF
--- a/notebooks/filter_US_MMS.ipynb
+++ b/notebooks/filter_US_MMS.ipynb
@@ -1,0 +1,77 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "4acbb233",
+   "metadata": {},
+   "source": [
+    "# Filter Data for US-MMS Site\n",
+    "This notebook loads a multi-feature dataset stored in a Parquet file and filters it to retain only the records corresponding to the US-MMS AmeriFlux location."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a07f3a7b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "from pathlib import Path\n",
+    "\n",
+    "# Path to your dataset\n",
+    "parquet_path = Path('path_to_dataset.parquet')\n",
+    "\n",
+    "# Load the dataset\n",
+    "# This expects latitude, longitude, and time columns\n",
+    "# along with any other features.\n",
+    "df = pd.read_parquet(parquet_path)\n",
+    "print('Rows before filtering:', len(df))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "33d376c8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Coordinates for US-MMS (Morgan Monroe State Forest)\n",
+    "US_MMS_LAT = 39.3232\n",
+    "US_MMS_LON = -86.4137\n",
+    "\n",
+    "tolerance = 0.01  # adjust depending on grid resolution\n",
+    "\n",
+    "site_df = df[(df['latitude'].sub(US_MMS_LAT).abs() <= tolerance) &\n",
+    "             (df['longitude'].sub(US_MMS_LON).abs() <= tolerance)].copy()\n",
+    "\n",
+    "print('Rows after filtering:', len(site_df))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2d5bd51e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Save the filtered data if needed\n",
+    "out_path = parquet_path.with_name(parquet_path.stem + '_US_MMS.parquet')\n",
+    "site_df.to_parquet(out_path, index=False)\n",
+    "print('Saved filtered site data to', out_path)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- add a short notebook for filtering a Parquet dataset to the US-MMS AmeriFlux site

## Testing
- `pip install nbformat -q`

------
https://chatgpt.com/codex/tasks/task_e_68409d0502848331bd26b631bf3d6778