### PR TITLE
Add SeasonalDecidOnset notebook

### DIFF
--- a/notebooks/CLM_SeasonalDecidOnset_python.ipynb
+++ b/notebooks/CLM_SeasonalDecidOnset_python.ipynb
@@ -1,0 +1,205 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "3679cab7",
+   "metadata": {},
+   "source": [
+    "# CLM SeasonalDecidOnset Phenology Onset/Offset in Python\n",
+    "\n",
+    "This notebook re-implements the CLM5 SeasonalDecidOnset subroutine using Python. It demonstrates how empirical phenology onset and offset can be calculated from daily temperature and photoperiod.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "40e5c82f",
+   "metadata": {},
+   "source": [
+    "## Algorithm Overview\n",
+    "- **Inputs:** daily minimum temperature, maximum temperature, photoperiod, and day-of-year arrays.\n",
+    "- **Parameters:**\n",
+    "  - `photoperiod_threshold` (hours)\n",
+    "  - `temperature_threshold` (°C)\n",
+    "  - `accumulation_days` (running window length)\n",
+    "  - `onset_flag` (`True` for onset, `False` for offset)\n",
+    "- For each day, compute binary forcing flags for photoperiod and temperature above thresholds.\n",
+    "- Maintain running sums over the last `accumulation_days`.\n",
+    "- **Onset:** first day when both sums are ≥ `accumulation_days`.\n",
+    "- **Offset:** first day (after onset) when both sums are < `accumulation_days`.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "730844b6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "params = {\n",
+    "    'photoperiod_threshold': 12.0,  # hours\n",
+    "    'temperature_threshold': 5.0,   # °C\n",
+    "    'accumulation_days': 7,         # days\n",
+    "}\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "75354ad2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def seasonal_decid_onset(tmin, tmax, photoperiod, doy, *,\n",
+    "                           photoperiod_threshold=12.0,\n",
+    "                           temperature_threshold=5.0,\n",
+    "                           accumulation_days=7,\n",
+    "                           onset_flag=True):\n",
+    "    \"\"\"Empirical onset/offset following CLM SeasonalDecidOnset.\n",
+    "\n",
+    "    Returns the day-of-year index for the event or -1 if not found.\n",
+    "    \"\"\"\n",
+    "    tmin = np.asarray(tmin)\n",
+    "    tmax = np.asarray(tmax)\n",
+    "    photoperiod = np.asarray(photoperiod)\n",
+    "    doy = np.asarray(doy)\n",
+    "    if not (len(tmin) == len(tmax) == len(photoperiod) == len(doy)):\n",
+    "        raise ValueError('All inputs must have the same length')\n",
+    "\n",
+    "    tmean = 0.5 * (tmin + tmax)\n",
+    "    phot_flag = (photoperiod >= photoperiod_threshold).astype(int)\n",
+    "    temp_flag = (tmean >= temperature_threshold).astype(int)\n",
+    "\n",
+    "    n = len(doy)\n",
+    "    phot_sum = np.zeros(n, dtype=int)\n",
+    "    temp_sum = np.zeros(n, dtype=int)\n",
+    "\n",
+    "    for i in range(n):\n",
+    "        start = max(0, i - accumulation_days + 1)\n",
+    "        phot_sum[i] = phot_flag[start:i+1].sum()\n",
+    "        temp_sum[i] = temp_flag[start:i+1].sum()\n",
+    "\n",
+    "    if onset_flag:\n",
+    "        for i in range(n):\n",
+    "            if phot_sum[i] >= accumulation_days and temp_sum[i] >= accumulation_days:\n",
+    "                return int(doy[i])\n",
+    "    else:\n",
+    "        triggered = False\n",
+    "        for i in range(n):\n",
+    "            if not triggered and phot_sum[i] >= accumulation_days and temp_sum[i] >= accumulation_days:\n",
+    "                triggered = True\n",
+    "            elif triggered and phot_sum[i] < accumulation_days and temp_sum[i] < accumulation_days:\n",
+    "                return int(doy[i])\n",
+    "    return -1\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "093ee3fe",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Example synthetic data\n",
+    "n_days = 60\n",
+    "doy = np.arange(1, n_days + 1)\n",
+    "tmin = np.linspace(-5, 15, n_days)\n",
+    "tmax = tmin + 10\n",
+    "photoperiod = 10 + 4 * np.sin(2 * np.pi * (doy - 80) / 365)\n",
+    "\n",
+    "onset_day = seasonal_decid_onset(tmin, tmax, photoperiod, doy, **params, onset_flag=True)\n",
+    "offset_day = seasonal_decid_onset(tmin, tmax, photoperiod, doy, **params, onset_flag=False)\n",
+    "print('Onset day:', onset_day)\n",
+    "print('Offset day:', offset_day)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "249266e5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.figure(figsize=(8,3))\n",
+    "plt.plot(doy, (tmin+tmax)/2, label='Tmean')\n",
+    "plt.plot(doy, photoperiod, label='Photoperiod')\n",
+    "if onset_day != -1:\n",
+    "    plt.axvline(onset_day, color='green', linestyle='--', label='Onset')\n",
+    "if offset_day != -1:\n",
+    "    plt.axvline(offset_day, color='red', linestyle='--', label='Offset')\n",
+    "plt.xlabel('Day of Year')\n",
+    "plt.legend()\n",
+    "plt.tight_layout()\n",
+    "plt.show()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cd0a16c6",
+   "metadata": {},
+   "source": [
+    "## Conclusion\n",
+    "The function `seasonal_decid_onset` reproduces the CLM SeasonalDecidOnset logic in Python, allowing onset and offset dates to be computed from time series of daily weather variables."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f39b9316",
+   "metadata": {},
+   "source": [
+    "## Testing the Module"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7d00df95",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Test 1: below thresholds\n",
+    "tmin = np.full(10, -5)\n",
+    "tmax = np.full(10, 0)\n",
+    "photoperiod = np.full(10, 8)\n",
+    "doy_test = np.arange(1, 11)\n",
+    "assert seasonal_decid_onset(tmin, tmax, photoperiod, doy_test, **params, onset_flag=True) == -1\n",
+    "assert seasonal_decid_onset(tmin, tmax, photoperiod, doy_test, **params, onset_flag=False) == -1\n",
+    "print('Test 1 passed')\n",
+    "\n",
+    "# Test 2: step function trigger on day 6\n",
+    "tmin = np.concatenate([np.zeros(5), np.full(5, 6)])\n",
+    "tmax = tmin + 5\n",
+    "photoperiod = np.concatenate([np.full(5, 11), np.full(5, 13)])\n",
+    "doy_test = np.arange(1, 11)\n",
+    "params_step = {'photoperiod_threshold': 12.0, 'temperature_threshold': 5.0, 'accumulation_days': 1}\n",
+    "assert seasonal_decid_onset(tmin, tmax, photoperiod, doy_test, **params_step, onset_flag=True) == 6\n",
+    "print('Test 2 passed')\n",
+    "\n",
+    "# Test 3: sliding window with accumulation_days=3\n",
+    "tmin = [0,6,6,6,0,0]\n",
+    "tmax = [10,12,12,12,10,10]\n",
+    "photoperiod = [11,12,12,12,11,11]\n",
+    "doy_test = np.arange(1,7)\n",
+    "params_sw = {'photoperiod_threshold': 12.0, 'temperature_threshold': 5.0, 'accumulation_days': 3}\n",
+    "assert seasonal_decid_onset(tmin, tmax, photoperiod, doy_test, **params_sw, onset_flag=True) == 4\n",
+    "print('Test 3 passed')\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- implement CLM SeasonalDecidOnset phenology onset/offset logic in Python
- provide example usage, plotting, and unit tests in a new notebook

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684630b2b5c88331bbd0d1544767b77d